### PR TITLE
Fix calculation of ISA remaining time

### DIFF
--- a/src/components/AuctionCounter.js
+++ b/src/components/AuctionCounter.js
@@ -4,7 +4,7 @@ import React, { Component } from 'react'
 
 class AuctionCounter extends Component {
   render () {
-    const { nextAuctionStartTime } = this.props
+    const { currentAuctionEndTime } = this.props
 
     const renderer = ({ days, hours, minutes, seconds, completed }) =>
       <div>
@@ -16,7 +16,7 @@ class AuctionCounter extends Component {
 
     return (
       <div className="container__auction-timer">
-        <Countdown date={nextAuctionStartTime} renderer={renderer} />
+        <Countdown date={currentAuctionEndTime} renderer={renderer} />
         <ul className="auction-timer__labels">
           <li>Days</li>
           <li>Hours</li>

--- a/src/components/AuctionCounter.js
+++ b/src/components/AuctionCounter.js
@@ -4,7 +4,11 @@ import React, { Component } from 'react'
 
 class AuctionCounter extends Component {
   render () {
-    const { currentAuctionEndTime } = this.props
+    const {
+      currentAuctionEndTime,
+      isAuctionActive,
+      nextAuctionStartTime
+    } = this.props
 
     const renderer = ({ days, hours, minutes, seconds, completed }) =>
       <div>
@@ -14,9 +18,13 @@ class AuctionCounter extends Component {
         <span className="auction-timer__section">{seconds}</span>
       </div>
 
+    const targetTime = isAuctionActive
+      ? currentAuctionEndTime
+      : nextAuctionStartTime
+
     return (
       <div className="container__auction-timer">
-        <Countdown date={currentAuctionEndTime} renderer={renderer} />
+        <Countdown date={targetTime} renderer={renderer} />
         <ul className="auction-timer__labels">
           <li>Days</li>
           <li>Hours</li>

--- a/src/components/AuctionCounterSm.js
+++ b/src/components/AuctionCounterSm.js
@@ -12,11 +12,11 @@ function AuctionCounterSm (props) {
     currentAuction,
     genesisTime,
     isAuctionActive,
-    nextAuctionStartTime
+    currentAuctionEndTime
   } = props
 
   const now = Date.now()
-  const remainingTime = nextAuctionStartTime - now
+  const remainingTime = currentAuctionEndTime - now
   const consumedTime = currentAuction === 0
     ? now - genesisTime
     : MS_PER_DAY - remainingTime
@@ -38,7 +38,7 @@ function AuctionCounterSm (props) {
       />}
       <span className="auction__counter-sm">
         <Countdown
-          date={nextAuctionStartTime}
+          date={currentAuctionEndTime}
           renderer={TimeString}
         />
       </span>

--- a/src/components/AuctionCounterSm.js
+++ b/src/components/AuctionCounterSm.js
@@ -10,9 +10,10 @@ const MS_PER_DAY = 24 * 60 * 60 * 1000
 function AuctionCounterSm (props) {
   const {
     currentAuction,
+    currentAuctionEndTime,
     genesisTime,
     isAuctionActive,
-    currentAuctionEndTime
+    nextAuctionStartTime
   } = props
 
   const now = Date.now()
@@ -38,7 +39,7 @@ function AuctionCounterSm (props) {
       />}
       <span className="auction__counter-sm">
         <Countdown
-          date={currentAuctionEndTime}
+          date={isAuctionActive ? currentAuctionEndTime : nextAuctionStartTime}
           renderer={TimeString}
         />
       </span>

--- a/src/reducers/auction.js
+++ b/src/reducers/auction.js
@@ -2,9 +2,10 @@ import { handleActions } from 'redux-actions'
 import BigNumber from 'bignumber.js'
 
 const MS_PER_DAY = 24 * 60 * 60 * 1000
+const ISA_DURATION_DAYS = 7
 
 const genesisTime = new Date('2018-06-18T00:00:00Z').getTime()
-const genesisTimePlus7 = genesisTime + 7 * MS_PER_DAY
+const genesisTimePlus7 = genesisTime + ISA_DURATION_DAYS * MS_PER_DAY
 
 const now = Date.now()
 
@@ -53,7 +54,10 @@ const reducer = handleActions(
         // calculate this as private so that logic should be replicated here.
         nextAuctionStartPrice: Date.now() < payload.genesisTime
           ? payload.lastPurchasePrice
-          : new BigNumber(payload.lastPurchasePrice).times(2).toString()
+          : new BigNumber(payload.lastPurchasePrice).times(2).toString(),
+        currentAuctionEndTime: payload.currentAuction === 0
+          ? payload.genesisTime + ISA_DURATION_DAYS * MS_PER_DAY
+          : payload.nextAuctionStartTime
       }
     }),
     AUCTION_STATUS_ERROR: (state, { payload }) => ({


### PR DESCRIPTION
ISA end time is now properly calculated as genesis + 7 days, irrespective of 1st daily auction start time.