### PR TITLE
Disable 7 days dropdown

### DIFF
--- a/src/components/MetPriceAreaBar.js
+++ b/src/components/MetPriceAreaBar.js
@@ -156,7 +156,10 @@ class MetPriceAreaBar extends Component {
     } = this.state
 
     const {
-      auction: { currentPrice }
+      auction: {
+        currentPrice,
+        isDailyAuction
+      }
     } = this.props
 
     const auctionChartData = this.parseHistory(data)
@@ -181,7 +184,9 @@ class MetPriceAreaBar extends Component {
                   <li onClick={() => this.changeTimeWindow('six')} className={timeWindow === 'six' ? '--active' : ''}><a>6 Hours</a></li>
                   <li onClick={() => this.changeTimeWindow('twelve')} className={timeWindow === 'twelve' ? '--active' : ''}><a>12 Hours</a></li>
                   <li onClick={() => this.changeTimeWindow('day')} className={timeWindow === 'day' ? '--active' : ''}><a>Day</a></li>
-                  <li onClick={() => this.changeTimeWindow('week')} className={timeWindow === 'week' ? '--active' : ''}><a>7 Days</a></li>
+                  {isDailyAuction
+                    ? <li onClick={() => this.changeTimeWindow('week')} className={timeWindow === 'week' ? '--active' : ''}><a>7 Days</a></li>
+                    : null}
                 </ul>
               </div>
             </div>


### PR DESCRIPTION
Until the daily auctions start, there will be no enough data points for the 7-days time period in the dashboard chart make sense.