### PR TITLE
Update wrong network banner

### DIFF
--- a/lib/metronome-status-js/es5.js
+++ b/lib/metronome-status-js/es5.js
@@ -189,6 +189,14 @@ function createMetApiStream(url) {
   return stream;
 }
 
+/**
+ * Create a stream that will emit Metronome status events.
+ *
+ * @param {Object} options Stream initialization options.
+ * @param {Object} [options.web3currentProvider] A Web3 provider instance.
+ * @param {string} [options.metApiUrl] The URL of the Metronome REST API.
+ * @returns {Object} The stream object.
+ */
 function createStatusStream(_ref3) {
   var web3currentProvider = _ref3.web3currentProvider,
       metApiUrl = _ref3.metApiUrl;

--- a/lib/metronome-status-js/index.js
+++ b/lib/metronome-status-js/index.js
@@ -181,7 +181,15 @@ function createMetApiStream(url) {
   return stream
 }
 
-function createStatusStream({ web3currentProvider, metApiUrl }) {
+/**
+ * Create a stream that will emit Metronome status events.
+ *
+ * @param {Object} options Stream initialization options.
+ * @param {Object} [options.web3currentProvider] A Web3 provider instance.
+ * @param {string} [options.metApiUrl] The URL of the Metronome REST API.
+ * @returns {Object} The stream object.
+ */
+function createStatusStream ({ web3currentProvider, metApiUrl }) {
   return web3currentProvider
     ? createWeb3Stream(web3currentProvider)
     : createMetApiStream(metApiUrl)

--- a/src/components/auction/BuyForm.js
+++ b/src/components/auction/BuyForm.js
@@ -8,12 +8,15 @@ import styled from 'styled-components'
 import utils from 'web3-utils'
 
 import withProviderPermission from '../../hocs/withProviderPermission'
+import WalletInfo from '../../providers/WalletInfo'
+import ChainWarning from '../common/ChainWarning'
 import DollarValue from '../common/DollarValue'
 import TextInput from '../common/TextInput'
 import FiatValue from '../common/FiatValue'
 import withWeb3 from '../../hocs/withWeb3'
 import EthValue from '../common/EthValue'
 import MetValue from '../common/MetValue'
+import Portal from '../common/Portal'
 
 const Container = styled.div`
   border-radius: 4px;
@@ -398,6 +401,10 @@ class BuyForm extends Component {
             </SubmitBtn>
           </div>
         </Form>
+        <Portal selector="#marquee">
+          <ChainWarning />
+        </Portal>
+        <WalletInfo />
       </Container>
     )
   }

--- a/src/components/common/ChainWarning.js
+++ b/src/components/common/ChainWarning.js
@@ -23,9 +23,11 @@ const Container = styled.div`
 const ChainWarning = ({ isCorrectChain, chains }) =>
   !isCorrectChain && (
     <Container>
-      Unsupported chain. Connect wallet to a valid chain:{' '}
+      Your web wallet is connected to the wrong chain. Switch to{' '}
       {chains
-        .map(({ displayName, chainId }) => `${displayName} (id: ${chainId})`)
+        .map(
+          ({ displayName, chainId }) => `${displayName} (net id: ${chainId})`
+        )
         .join(', ')}
     </Container>
   )

--- a/src/components/common/ChainWarning.js
+++ b/src/components/common/ChainWarning.js
@@ -4,7 +4,7 @@ import React from 'react'
 
 const Container = styled.div`
   position: absolute;
-  top: 40px;
+  top: 102px;
   z-index: 2;
   right: 0;
   left: 0;
@@ -16,7 +16,15 @@ const Container = styled.div`
 
   body.scrolled & {
     position: fixed;
-    top: 54px;
+    top: 62px;
+  }
+
+  @media (min-width: 992px) {
+    top: 40px;
+
+    body.scrolled & {
+      top: 54px;
+    }
   }
 `
 

--- a/src/components/converter/ConvertForm.js
+++ b/src/components/converter/ConvertForm.js
@@ -11,11 +11,14 @@ import utils from 'web3-utils'
 
 import withProviderPermission from '../../hocs/withProviderPermission'
 import MinReturnCheckbox from './MinReturnCheckbox'
+import WalletInfo from '../../providers/WalletInfo'
+import ChainWarning from '../common/ChainWarning'
 import DollarValue from '../common/DollarValue'
 import TextInput from '../common/TextInput'
 import withWeb3 from '../../hocs/withWeb3'
 import EthValue from '../common/EthValue'
 import MetValue from '../common/MetValue'
+import Portal from '../common/Portal'
 
 const Container = styled.div`
   border-radius: 4px;
@@ -475,6 +478,10 @@ class ConvertForm extends Component {
             </SubmitBtn>
           </div>
         </Form>
+        <Portal selector="#marquee">
+          <ChainWarning />
+        </Portal>
+        <WalletInfo />
       </Container>
     )
   }

--- a/src/index.js
+++ b/src/index.js
@@ -11,12 +11,10 @@ import config from './config'
 
 import MetronomeStatus from './providers/MetronomeStatus'
 import WalletVersion from './providers/WalletVersion'
-import WalletInfo from './providers/WalletInfo'
 import Rates from './providers/Rates'
 
 import DashboardPage from './components/dashboard/Dashboard'
 import ConverterPage from './components/converter/Converter'
-import ChainWarning from './components/common/ChainWarning'
 import AuctionPage from './components/auction/Auction'
 import WalletPage from './components/wallet/Wallet'
 import HomePage from './components/home/Home'
@@ -79,10 +77,6 @@ if (rootElement || marqueeElement) {
         )}
         <MetronomeStatus />
         <WalletVersion />
-        <Portal selector="#marquee">
-          <ChainWarning />
-        </Portal>
-        <WalletInfo />
         <ReactHint autoPosition events />
         <Rates />
       </React.Fragment>

--- a/src/providers/MetronomeStatus.js
+++ b/src/providers/MetronomeStatus.js
@@ -18,7 +18,6 @@ class MetronomeStatus extends Component {
 
   initStream() {
     this.statusStream = createMetronomeStatusStream({
-      web3currentProvider: window.web3 && window.web3.currentProvider,
       metApiUrl: this.props.metApiUrl
     })
     this.statusStream.on('data', this.props.onData)


### PR DESCRIPTION
The banner will be shown only when buying/converting, not on every page. It was also reworded.

To show correct status/ticker/dashboard data, this is now obtained from the API regardless having a web wallet (like MetaMask).

![image](https://user-images.githubusercontent.com/2621975/64358411-ce281980-cfdc-11e9-8aa6-2a3ba8872f80.png)
