### PR TITLE
Fix GA tracking ID injection

### DIFF
--- a/public/about/index.html
+++ b/public/about/index.html
@@ -15,7 +15,7 @@
       type="text/css"
     />
     <link
-      href="../dist/css/main.css?cb=1568077553948"
+      href="../dist/css/main.css?cb=1569541372138"
       rel="stylesheet"
       type="text/css"
     />
@@ -818,10 +818,10 @@
     </footer>
     <!-- /FOOTER -->
     <!-- SCRIPTS -->
-    <script src="../dist/js/main.js?cb=1568077553948"></script>
+    <script src="../dist/js/main.js?cb=1569541372138"></script>
     <script
       async
-      src="https://www.googletagmanager.com/gtag/js?id=%3C%-htmlWebpackPlugin.options.gaTrackingId%%3E"
+      src="https://www.googletagmanager.com/gtag/js?id=<%-htmlWebpackPlugin.options.gaTrackingId%>"
     ></script>
   </body>
 </html>

--- a/public/auction/index.html
+++ b/public/auction/index.html
@@ -15,7 +15,7 @@
       type="text/css"
     />
     <link
-      href="../dist/css/main.css?cb=1568077553948"
+      href="../dist/css/main.css?cb=1569541372138"
       rel="stylesheet"
       type="text/css"
     />
@@ -421,10 +421,10 @@
     </footer>
     <!-- /FOOTER -->
     <!-- SCRIPTS -->
-    <script src="../dist/js/main.js?cb=1568077553948"></script>
+    <script src="../dist/js/main.js?cb=1569541372138"></script>
     <script
       async
-      src="https://www.googletagmanager.com/gtag/js?id=%3C%-htmlWebpackPlugin.options.gaTrackingId%%3E"
+      src="https://www.googletagmanager.com/gtag/js?id=<%-htmlWebpackPlugin.options.gaTrackingId%>"
     ></script>
   </body>
 </html>

--- a/public/build/index.html
+++ b/public/build/index.html
@@ -15,7 +15,7 @@
       type="text/css"
     />
     <link
-      href="../dist/css/main.css?cb=1568077553948"
+      href="../dist/css/main.css?cb=1569541372138"
       rel="stylesheet"
       type="text/css"
     />
@@ -488,10 +488,10 @@
     </footer>
     <!-- /FOOTER -->
     <!-- SCRIPTS -->
-    <script src="../dist/js/main.js?cb=1568077553948"></script>
+    <script src="../dist/js/main.js?cb=1569541372138"></script>
     <script
       async
-      src="https://www.googletagmanager.com/gtag/js?id=%3C%-htmlWebpackPlugin.options.gaTrackingId%%3E"
+      src="https://www.googletagmanager.com/gtag/js?id=<%-htmlWebpackPlugin.options.gaTrackingId%>"
     ></script>
   </body>
 </html>

--- a/public/buy/index.html
+++ b/public/buy/index.html
@@ -15,7 +15,7 @@
       type="text/css"
     />
     <link
-      href="../dist/css/main.css?cb=1568077553948"
+      href="../dist/css/main.css?cb=1569541372138"
       rel="stylesheet"
       type="text/css"
     />
@@ -525,10 +525,10 @@
     </footer>
     <!-- /FOOTER -->
     <!-- SCRIPTS -->
-    <script src="../dist/js/main.js?cb=1568077553948"></script>
+    <script src="../dist/js/main.js?cb=1569541372138"></script>
     <script
       async
-      src="https://www.googletagmanager.com/gtag/js?id=%3C%-htmlWebpackPlugin.options.gaTrackingId%%3E"
+      src="https://www.googletagmanager.com/gtag/js?id=<%-htmlWebpackPlugin.options.gaTrackingId%>"
     ></script>
   </body>
 </html>

--- a/public/converter/index.html
+++ b/public/converter/index.html
@@ -15,7 +15,7 @@
       type="text/css"
     />
     <link
-      href="../dist/css/main.css?cb=1568077553948"
+      href="../dist/css/main.css?cb=1569541372138"
       rel="stylesheet"
       type="text/css"
     />
@@ -423,10 +423,10 @@
     </footer>
     <!-- /FOOTER -->
     <!-- SCRIPTS -->
-    <script src="../dist/js/main.js?cb=1568077553948"></script>
+    <script src="../dist/js/main.js?cb=1569541372138"></script>
     <script
       async
-      src="https://www.googletagmanager.com/gtag/js?id=%3C%-htmlWebpackPlugin.options.gaTrackingId%%3E"
+      src="https://www.googletagmanager.com/gtag/js?id=<%-htmlWebpackPlugin.options.gaTrackingId%>"
     ></script>
   </body>
 </html>

--- a/public/dashboard/index.html
+++ b/public/dashboard/index.html
@@ -15,7 +15,7 @@
       type="text/css"
     />
     <link
-      href="../dist/css/main.css?cb=1568077553948"
+      href="../dist/css/main.css?cb=1569541372138"
       rel="stylesheet"
       type="text/css"
     />
@@ -426,10 +426,10 @@
     </footer>
     <!-- /FOOTER -->
     <!-- SCRIPTS -->
-    <script src="../dist/js/main.js?cb=1568077553948"></script>
+    <script src="../dist/js/main.js?cb=1569541372138"></script>
     <script
       async
-      src="https://www.googletagmanager.com/gtag/js?id=%3C%-htmlWebpackPlugin.options.gaTrackingId%%3E"
+      src="https://www.googletagmanager.com/gtag/js?id=<%-htmlWebpackPlugin.options.gaTrackingId%>"
     ></script>
   </body>
 </html>

--- a/public/engage/index.html
+++ b/public/engage/index.html
@@ -720,7 +720,7 @@
     <script src="../dist/js/main.js?cb=1568077553948"></script>
     <script
       async
-      src="https://www.googletagmanager.com/gtag/js?id=%3C%-htmlWebpackPlugin.options.gaTrackingId%%3E"
+      src="https://www.googletagmanager.com/gtag/js?id=<%-htmlWebpackPlugin.options.gaTrackingId%>"
     ></script>
   </body>
 </html>

--- a/public/index.html
+++ b/public/index.html
@@ -15,7 +15,7 @@
       type="text/css"
     />
     <link
-      href="./dist/css/main.css?cb=1568077553948"
+      href="./dist/css/main.css?cb=1569541372138"
       rel="stylesheet"
       type="text/css"
     />
@@ -966,11 +966,11 @@
     </footer>
     <!-- /FOOTER -->
     <!-- SCRIPTS -->
-    <script src="./dist/js/main.js?cb=1568077553948"></script>
+    <script src="./dist/js/main.js?cb=1569541372138"></script>
     <script src="./dist/lib/typed/typed.js"></script>
     <script
       async
-      src="https://www.googletagmanager.com/gtag/js?id=&lt;%-htmlWebpackPlugin.options.gaTrackingId%&gt;"
+      src="https://www.googletagmanager.com/gtag/js?id=<%-htmlWebpackPlugin.options.gaTrackingId%>"
     ></script>
   </body>
 </html>

--- a/public/privacy/index.html
+++ b/public/privacy/index.html
@@ -15,7 +15,7 @@
       type="text/css"
     />
     <link
-      href="../dist/css/main.css?cb=1568077553948"
+      href="../dist/css/main.css?cb=1569541372138"
       rel="stylesheet"
       type="text/css"
     />
@@ -541,10 +541,10 @@
     </footer>
     <!-- /FOOTER -->
     <!-- SCRIPTS -->
-    <script src="../dist/js/main.js?cb=1568077553948"></script>
+    <script src="../dist/js/main.js?cb=1569541372138"></script>
     <script
       async
-      src="https://www.googletagmanager.com/gtag/js?id=%3C%-htmlWebpackPlugin.options.gaTrackingId%%3E"
+      src="https://www.googletagmanager.com/gtag/js?id=<%-htmlWebpackPlugin.options.gaTrackingId%>"
     ></script>
   </body>
 </html>

--- a/public/roadmap/index.html
+++ b/public/roadmap/index.html
@@ -15,7 +15,7 @@
       type="text/css"
     />
     <link
-      href="../dist/css/main.css?cb=1568077553948"
+      href="../dist/css/main.css?cb=1569541372138"
       rel="stylesheet"
       type="text/css"
     />
@@ -795,10 +795,10 @@
     </footer>
     <!-- /FOOTER -->
     <!-- SCRIPTS -->
-    <script src="../dist/js/main.js?cb=1568077553948"></script>
+    <script src="../dist/js/main.js?cb=1569541372138"></script>
     <script
       async
-      src="https://www.googletagmanager.com/gtag/js?id=%3C%-htmlWebpackPlugin.options.gaTrackingId%%3E"
+      src="https://www.googletagmanager.com/gtag/js?id=<%-htmlWebpackPlugin.options.gaTrackingId%>"
     ></script>
   </body>
 </html>

--- a/public/thank-you/index.html
+++ b/public/thank-you/index.html
@@ -15,7 +15,7 @@
       type="text/css"
     />
     <link
-      href="../dist/css/main.css?cb=1568077553948"
+      href="../dist/css/main.css?cb=1569541372138"
       rel="stylesheet"
       type="text/css"
     />
@@ -377,10 +377,10 @@
     </footer>
     <!-- /FOOTER -->
     <!-- SCRIPTS -->
-    <script src="../dist/js/main.js?cb=1568077553948"></script>
+    <script src="../dist/js/main.js?cb=1569541372138"></script>
     <script
       async
-      src="https://www.googletagmanager.com/gtag/js?id=%3C%-htmlWebpackPlugin.options.gaTrackingId%%3E"
+      src="https://www.googletagmanager.com/gtag/js?id=<%-htmlWebpackPlugin.options.gaTrackingId%>"
     ></script>
   </body>
 </html>

--- a/public/wallet/index.html
+++ b/public/wallet/index.html
@@ -15,7 +15,7 @@
       type="text/css"
     />
     <link
-      href="../dist/css/main.css?cb=1568077553948"
+      href="../dist/css/main.css?cb=1569541372138"
       rel="stylesheet"
       type="text/css"
     />
@@ -473,10 +473,10 @@
     </footer>
     <!-- /FOOTER -->
     <!-- SCRIPTS -->
-    <script src="../dist/js/main.js?cb=1568077553948"></script>
+    <script src="../dist/js/main.js?cb=1569541372138"></script>
     <script
       async
-      src="https://www.googletagmanager.com/gtag/js?id=%3C%-htmlWebpackPlugin.options.gaTrackingId%%3E"
+      src="https://www.googletagmanager.com/gtag/js?id=<%-htmlWebpackPlugin.options.gaTrackingId%>"
     ></script>
   </body>
 </html>


### PR DESCRIPTION
The template delimiters were accidentally replaced/sanitized in a previous commit. This PR restores the proper markup.

Fixes #180 