### PR TITLE
Reconfigure Travis to deploy to S3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,35 +1,48 @@
-dist: trusty
-sudo: false
-
 language: node_js
-node_js:
-  - '8.15'
+node_js: "10"
+cache: npm
 
-notifications:
-  on_success: never
-  on_failure: always
+branches:
+  only:
+    - develop
+    - master
 
-cache:
-  directories:
-    - node_modules
+env:
+  global:
+    - PATH=$HOME/.local/bin:$PATH # for `aws`
 
-script:
-  - echo $TRAVIS_TAG
+script: "echo Skipping tests for $TRAVIS_COMMIT"
 
 before_deploy:
   - npm run build
-  - ls .
-  - zip -r build-$TRAVIS_TAG.zip build
-  - echo "Bundle SHA-256 checksum $(sha256sum build-$TRAVIS_TAG.zip)"
+  - pip install --user awscli
+  - aws s3 rm s3://$S3_BUCKET --recursive
 
 deploy:
-  provider: releases
-  api_key: $GH_TOKEN
-  file: build-$TRAVIS_TAG.zip
-  skip_cleanup: true
-  draft: true
-  name: $TRAVIS_TAG
-  on:
-    tags: true
-    branch: master
-    condition: $TRAVIS_TAG =~ ^[0-9]+-[0-9]+-[0-9]+-[0-9]+$
+  - provider: s3
+    access_key_id: $AWS_ACCESS_KEY_ID
+    secret_access_key: $AWS_SECRET_ACCESS_KEY
+    bucket: $S3_BUCKET
+    skip_cleanup: true
+    region: us-east-2
+    local_dir: build
+    on:
+      branch: develop
+    cache_control: "max-age=$CACHE_MAX_AGE"
+
+  - provider: s3
+    access_key_id: $AWS_ACCESS_KEY_ID
+    secret_access_key: $AWS_SECRET_ACCESS_KEY
+    bucket: $S3_BUCKET
+    skip_cleanup: true
+    region: us-east-2
+    local_dir: build
+    on:
+      branch: master
+      tags: true
+      condition: $TRAVIS_TAG =~ ^\d{4}-\d{2}-\d{2}-\d+$
+    cache_control: "max-age=$CACHE_MAX_AGE"
+
+after_deploy:
+  - aws configure set preview.cloudfront true
+  # - aws cloudfront create-invalidation --distribution-id $CLOUDFRONT_DISTRIBUTION_ID --paths "/*"


### PR DESCRIPTION
This is the first step in updating the deploy strategy to target S3.

All testing of this strategy will happen on the `develop` branch, that will be automatically deployed to the staging site. Only when that build pipeline is fully functional, changes will be merged into `master`.

Travis is set up with environment variables that depend on the branch. I.e. `S3_BUCKET` is set to `metronome.io` when building the `master` branch but to the staging URL when building `develop`.